### PR TITLE
Fix c_char type error (i8 vs u8) when building on linux arm64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,7 +634,7 @@ impl std::iter::Iterator for MetadataIterator {
                 let mut buf: *mut Buffer = std::ptr::null_mut();
                 let key = match void_result(blackmagic_raw_metadata_iterator_get_key(self.implementation, &mut buf)) {
                     Ok(_) => {
-                        let key = std::ffi::CStr::from_ptr(buffer_data(buf) as *const i8).to_str().unwrap_or("").to_string();
+                        let key = std::ffi::CStr::from_ptr(buffer_data(buf) as *const c_char).to_str().unwrap_or("").to_string();
                         buffer_release(buf);
                         key
                     },
@@ -657,7 +657,7 @@ impl std::iter::Iterator for MetadataIterator {
                     _BlackmagicRawVariantType_blackmagicRawVariantTypeString => {
                         let mut buf: *mut Buffer = std::ptr::null_mut();
                         blackmagic_raw_variant_get_string(&mut value, &mut buf);
-                        let s = std::ffi::CStr::from_ptr(buffer_data(buf) as *const i8).to_str().unwrap_or("").to_string();
+                        let s = std::ffi::CStr::from_ptr(buffer_data(buf) as *const c_char).to_str().unwrap_or("").to_string();
                         buffer_release(buf);
                         Value::String(s)
                     },


### PR DESCRIPTION
Trying to build this on linux arm64 (via docker) currently gives this error:
```sh
#10 41.70      Running `/workspace/target/debug/build/blackmagic-raw-ac69c2157ddb4c8d/build-script-build`
#10 42.31      Running `rustc --crate-name blackmagic_raw src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=fdfd7150520f783d -C extra-filename=-fdfd7150520f783d --out-dir /workspace/target/debug/deps -C incremental=/workspace/target/debug/incremental -L dependency=/workspace/target/debug/deps --extern simple_error=/workspace/target/debug/deps/libsimple_error-64d997a5a27f0c92.rmeta -L native=/workspace/target/debug/build/blackmagic-raw-6065ddde59c2b3c6/out -l stdc++ -l static=braw`
#10 42.43 error[E0308]: mismatched types
#10 42.43    --> src/lib.rs:637:60
#10 42.43     |
#10 42.43 637 |                         let key = std::ffi::CStr::from_ptr(buffer_data(buf) as *const i8).to_str().unwrap_or("").to_string();
#10 42.43     |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
#10 42.43     |
#10 42.43     = note: expected raw pointer `*const u8`
#10 42.43                found raw pointer `*const i8`
#10 42.43 
#10 42.44 error[E0308]: mismatched types
#10 42.44    --> src/lib.rs:660:58
#10 42.44     |
#10 42.44 660 |                         let s = std::ffi::CStr::from_ptr(buffer_data(buf) as *const i8).to_str().unwrap_or("").to_string();
#10 42.44     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
#10 42.44     |
#10 42.44     = note: expected raw pointer `*const u8`
#10 42.44                found raw pointer `*const i8`
#10 42.44 
#10 42.45 For more information about this error, try `rustc --explain E0308`.
#10 42.47 error: could not compile `blackmagic-raw` due to 2 previous errors
#10 42.47 
#10 42.47 Caused by:
#10 42.47   process didn't exit successfully: `rustc --crate-name blackmagic_raw src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=fdfd7150520f783d -C extra-filename=-fdfd7150520f783d --out-dir /workspace/target/debug/deps -C incremental=/workspace/target/debug/incremental -L dependency=/workspace/target/debug/deps --extern simple_error=/workspace/target/debug/deps/libsimple_error-64d997a5a27f0c92.rmeta -L native=/workspace/target/debug/build/blackmagic-raw-6065ddde59c2b3c6/out -l stdc++ -l static=braw` (exit status: 1)
```

Apparently `c_char` is aliased to `u8` on linux/arm64, whereas it's `i8` on linux/amd64.
Some context here: https://github.com/rust-lang/rust/issues/60226
And see `c_char_definition` here: https://doc.rust-lang.org/src/std/os/raw/mod.rs.html#103

Tested with this dockerfile (see results below):
```
FROM ubuntu:focal

RUN apt-get update && apt-get install -y build-essential clang curl

RUN curl https://sh.rustup.rs -sSf | sh -s -- --profile default -y
ENV PATH="${PATH}:/root/.cargo/bin"

WORKDIR /workspace
COPY . .

RUN cargo build --verbose
```

Test results:
* before fix
  * m1 mac `docker build .` -> i8/u8 type error
  * intel mac `docker build .` -> no error
  * intel mac `docker build --platform arm64 .` -> i8/u8 type error
* after fix
  * m1 mac `docker build .` -> no error
  * intel mac `docker build .` -> no error
  * intel mac `docker build --platform arm64 .` -> no error